### PR TITLE
Implement #6 , #8 , #9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
     ],
     "require": {
         "php": ">=5.5.9",
+        "illuminate/contracts": "~5.1",
         "illuminate/bus": "~5.1",
         "illuminate/database": "~5.1",
         "illuminate/queue": "~5.1",

--- a/database/migrations/2016_10_20_071609_create_Tracks_table.php
+++ b/database/migrations/2016_10_20_071609_create_Tracks_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateTracksTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('tracks', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('driver');
+            $table->integer('queue_id');
+            $table->text('payload');
+            $table->integer('attempts');
+            $table->text('meta')->nullable();
+            $table->timestamp('queue_at');
+            $table->timestamp('process_at');
+            $table->timestamp('succeed_at');
+            $table->timestamp('failed_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::drop('tracks');
+    }
+}

--- a/src/Facades/QWatch.php
+++ b/src/Facades/QWatch.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Maqe\Qwatcher\Facades;
+
+use Illuminate\Support\Facades\Facade;
+
+/**
+ * This is the authorizer facade class.
+ *
+ */
+class Qwatch extends Facade
+{
+    /**
+     * Get the registered name of the component.
+     *
+     * @return string
+     */
+    protected static function getFacadeAccessor()
+    {
+        return 'Qwatch';
+    }
+}

--- a/src/Qwatcher.php
+++ b/src/Qwatcher.php
@@ -1,6 +1,148 @@
 <?php namespace Maqe\Qwatcher;
 
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Maqe\Qwatcher\Tracks\TracksInterface;
+use Maqe\Qwatcher\Tracks\Tracks;
+use Carbon\Carbon;
+
 class Qwatcher
 {
     public function __construct() {}
+
+    /**
+     * Insert or update Track table depand on TracksInterface sub class
+     *
+     * @param  TracksInterface $tracks      Sub class that implements TracksInterface
+     * @return mixed
+     */
+    public function tracks(TracksInterface $tracks)
+    {
+        return $tracks;
+    }
+
+    /**
+     * Get the list of the queue track
+     *
+     * @return collection
+     */
+    public function all()
+    {
+        return $this->transforms(Tracks::all());
+    }
+
+    /**
+     * Get the track record by id
+     *
+     * @param  $id          The track id
+     * @return object
+     */
+    public function getById($id)
+    {
+        return $this->transform(Tracks::where('id', $id)->firstOrFail());
+    }
+
+    /**
+     * Get the track record by current status
+     *
+     * @param  $status      The track status
+     * @return collection
+     */
+    public function getByStatus($status)
+    {
+        $builder = Tracks::where("queue_at", '>', '0000-00-00 00:00:00');
+        $methodName = 'filterBy'.ucfirst($status);
+
+        if (method_exists($this, $methodName)) {
+            $this->{$methodName}($builder);
+        } else {
+            throw new \Exception('"'.$status.'" doesn\'t not exist');
+        }
+
+        return $this->transforms($builder->get());
+    }
+
+    /**
+     * Get the track record by job name
+     *
+     * @param  $name        The job name
+     * @return collection
+     */
+    public function getByJobName($name)
+    {
+        $collecName = str_replace('\\', '%',$name);
+        $condition = "`tracks`.`meta` LIKE '%\"job_name\":\"{$collecName}\"%'";
+
+        return $this->transforms(Tracks::whereRaw($condition)->get());
+    }
+
+    /**
+     * Transform records in tracks collection
+     *
+     * @param  Collection $tracks   The tracks collection
+     * @return Collection           The tracks collection after transform
+     */
+    protected function transform($track)
+    {
+        $track->meta = ($track->meta) ? json_decode($track->meta) : null;
+        $track->payload = ($track->payload) ? json_decode($track->payload) : null;
+        $track->payload->data->command = ($track->payload->data->command) ? unserialize($track->payload->data->command) : null;
+
+        return $track;
+    }
+
+    /**
+     * Transform records in tracks collection
+     *
+     * @param  Collection $tracks   The tracks collection
+     * @return Collection           The tracks collection after transform
+     */
+    protected function transforms($tracks)
+    {
+        return $tracks->each(function($track) {
+            $track = $this->transform($track);
+        });
+    }
+
+    /**
+     * Filter by process date is not null
+     * - succeed and failed must be null
+     *
+     * @param  Builder $builder The tracks builder
+     * @return Builder          The query builder with filter applied.
+     */
+    protected function filterByProcess(Builder $builder)
+    {
+        return $builder->where("process_at", '>', '0000-00-00 00:00:00')
+            ->where('succeed_at', '=', '0000-00-00 00:00:00')
+            ->where('failed_at', '=', '0000-00-00 00:00:00');
+    }
+
+    /**
+     * Filter by succeed date is not null
+     * - process is not null
+     * - failed is null
+     *
+     * @param  Builder $builder The tracks builder
+     * @return Builder          The query builder with filter applied.
+     */
+    protected function filterBySucceed(Builder $builder)
+    {
+        return $builder
+            ->where('succeed_at', '>', '0000-00-00 00:00:00')
+            ->where('failed_at', '=', '0000-00-00 00:00:00');
+    }
+
+    /**
+     * Filter by failed date is not null
+     * - succeed is null
+     *
+     * @param  Builder $builder The tracks builder
+     * @return Builder          The query builder with filter applied.
+     */
+    protected function filterByFailed(Builder $builder)
+    {
+        return $builder->where('succeed_at', '=', '0000-00-00 00:00:00')
+            ->where('failed_at', '>', '0000-00-00 00:00:00');
+    }
 }

--- a/src/QwatcherServiceProvider.php
+++ b/src/QwatcherServiceProvider.php
@@ -1,0 +1,62 @@
+<?php namespace Maqe\Qwatcher;
+
+use Queue;
+use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Facades\Log;
+use Maqe\Qwatcher\Facades\Qwatch;
+use Maqe\Qwatcher\Tracks\FailedTracks;
+use Maqe\Qwatcher\Tracks\ProcessTracks;
+use Maqe\Qwatcher\Tracks\SucceedTracks;
+
+class QwatcherServiceProvider extends ServiceProvider
+{
+    /**
+     * Bootstrap any application services.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        Queue::before(function ($job) {
+            Qwatch::tracks(new ProcessTracks($job->job->getJobId(), $job->job));
+        });
+
+        Queue::after(function ($job) {
+            Qwatch::tracks(new SucceedTracks($job->job->getJobId(), $job->job));
+        });
+
+        Queue::failing(function ($job) {
+            Qwatch::tracks(new FailedTracks($job->job->getJobId(), $job->job));
+        });
+    }
+
+    /**
+     * Register the service provider.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        /**
+        * publish migrations
+        */
+        $this->publishes([__DIR__ . '/../database/migrations' => database_path('migrations')], 'migrations');
+
+        /**
+        * Register Facade
+        */
+        $this->app->bind('Qwatch', function () {
+            return (new Qwatcher);
+        });
+    }
+
+    /**
+     * Get the services provided by the provider.
+     *
+     * @return array
+     */
+    public function provides()
+    {
+        return ['Qwatch'];
+    }
+}

--- a/src/Tracks/Enums/StatusType.php
+++ b/src/Tracks/Enums/StatusType.php
@@ -1,0 +1,10 @@
+<?php namespace Maqe\Qwatcher\Tracks\Enums;
+
+class StatusType
+{
+    const QUEUE = 'queue';
+    const PROCESS = 'process';
+    const SUCCEED = 'succeed';
+    const FAILED = 'failed';
+
+}

--- a/src/Tracks/FailedTracks.php
+++ b/src/Tracks/FailedTracks.php
@@ -1,0 +1,16 @@
+<?php namespace Maqe\Qwatcher\Tracks;
+
+use Maqe\Qwatcher\Tracks\Enums\StatusType;
+
+class FailedTracks extends TracksAbstract implements TracksInterface
+{
+    public function __construct($id, $job = null, array $meta = [])
+    {
+        return $this->pushToTracks($id, $job);
+    }
+
+    public function pushToTracks($id, $job = null, array $meta = [])
+    {
+        return $this->update($id, $job, StatusType::FAILED);
+    }
+}

--- a/src/Tracks/ProcessTracks.php
+++ b/src/Tracks/ProcessTracks.php
@@ -1,0 +1,16 @@
+<?php namespace Maqe\Qwatcher\Tracks;
+
+use Maqe\Qwatcher\Tracks\Enums\StatusType;
+
+class ProcessTracks extends TracksAbstract implements TracksInterface
+{
+    public function __construct($id, $job = null, array $meta = [])
+    {
+        return $this->pushToTracks($id, $job);
+    }
+
+    public function pushToTracks($id, $job = null, array $meta = [])
+    {
+        return $this->update($id, $job, StatusType::PROCESS);
+    }
+}

--- a/src/Tracks/QueueTracks.php
+++ b/src/Tracks/QueueTracks.php
@@ -1,0 +1,14 @@
+<?php namespace Maqe\Qwatcher\Tracks;
+
+class QueueTracks extends TracksAbstract implements TracksInterface
+{
+    public function __construct($id, $job = null, array $meta = [])
+    {
+        return $this->pushToTracks($id, $job, $meta);
+    }
+
+    public function pushToTracks($id, $job = null, array $meta = [])
+    {
+        return $this->create($id, $job, $meta);
+    }
+}

--- a/src/Tracks/SucceedTracks.php
+++ b/src/Tracks/SucceedTracks.php
@@ -1,0 +1,16 @@
+<?php namespace Maqe\Qwatcher\Tracks;
+
+use Maqe\Qwatcher\Tracks\Enums\StatusType;
+
+class SucceedTracks extends TracksAbstract implements TracksInterface
+{
+    public function __construct($id, $job = null, array $meta = [])
+    {
+        return $this->pushToTracks($id, $job);
+    }
+
+    public function pushToTracks($id, $job = null, array $meta = [])
+    {
+        return $this->update($id, $job, StatusType::SUCCEED);
+    }
+}

--- a/src/Tracks/Tracks.php
+++ b/src/Tracks/Tracks.php
@@ -1,0 +1,15 @@
+<?php namespace Maqe\Qwatcher\Tracks;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Tracks extends Model
+{
+    protected $table = 'tracks';
+
+    protected $fillable = [
+        'driver', 'queue_id', 'queue', 'payload', 'attempts', 'meta',
+        'queue_at', 'process_at', 'success_at', 'failed_at'
+    ];
+
+    public $timestamps = false;
+}

--- a/src/Tracks/TracksAbstract.php
+++ b/src/Tracks/TracksAbstract.php
@@ -1,0 +1,71 @@
+<?php namespace Maqe\Qwatcher\Tracks;
+
+use Illuminate\Queue\Queue;
+use Carbon\Carbon;
+use Maqe\Qwatcher\Tracks\Enums\StatusType;
+
+abstract class TracksAbstract extends Queue
+{
+    /**
+     * Push job to tracks table
+     *
+     * @param  $id          The queue id
+     * @param  $job         The queue job object
+     * @param  array  $meta The meta data array
+     * @return mixed
+     */
+    abstract public function pushToTracks($id, $job = null, array $meta = []);
+
+    /**
+     * Create tracks record from job
+     *
+     * @param  mixed    $job        The queue job object
+     * @param  array    $meta       The meta data array
+     * @return integer  $id         The new tracks id
+     */
+    protected function create($id, $job = null, array $meta = [])
+    {
+        return Tracks::create($this->prepareRecord($id, $job, $meta))->id;
+    }
+
+    /**
+     * Update status tracks record by queue id and status type
+     *
+     * @param  integer  $id         The queue id to track queue record
+     * @param  enum     $status     The status tracks type
+     * @return boolean|mixed        The update result
+     */
+    protected function update($id, $job, $status)
+    {
+        return Tracks::where('queue_id', $id)->update(['attempts' => $job->attempts(), "{$status}_at" => Carbon::now()]);
+    }
+
+    /**
+     * Prepare record before create new record
+     *
+     * @param  mixed $job           The queue job object
+     * @return array                The array for input to database
+     */
+    protected function prepareRecord($id, $job, array $meta = [])
+    {
+        return [
+            'driver' => env('QUEUE_DRIVER', 'sync'),
+            'queue_id' => $id,
+            'payload' => $this->createPayload($job),
+            'attempts' => 0,
+            'meta' => json_encode($this->setMetaData($job, $meta)),
+            'queue_at' => Carbon::now()
+        ];
+    }
+
+    /**
+     * Include default meta data job_name into meta column
+     *
+     * @param $job                  The queue job object
+     * @param array  $meta          The meta array after add default
+     */
+    protected function setMetaData($job, array $meta = [])
+    {
+        return array_add($meta, 'job_name', get_class($job));
+    }
+}

--- a/src/Tracks/TracksInterface.php
+++ b/src/Tracks/TracksInterface.php
@@ -1,0 +1,3 @@
+<?php namespace Maqe\Qwatcher\Tracks;
+
+interface TracksInterface {}

--- a/src/Traits/WatchableDispatchesJobs.php
+++ b/src/Traits/WatchableDispatchesJobs.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Maqe\Qwatcher\Traits;
+
+use DB;
+use Illuminate\Contracts\Bus\Dispatcher;
+use Maqe\Qwatcher\Facades\Qwatch;
+use Maqe\Qwatcher\Tracks\QueueTracks;
+
+trait WatchableDispatchesJobs
+{
+    /**
+     * Dispatch a job to its appropriate handler.
+     *
+     * @param  mixed  $job
+     * @return mixed
+     */
+    public function dispatch($job, array $meta = [])
+    {
+        $id = app(Dispatcher::class)->dispatch($job);
+
+        Qwatch::tracks(new QueueTracks($id, $job, $meta));
+
+        return $id;
+    }
+
+    /**
+     * Dispatch a command to its appropriate handler in the current process.
+     *
+     * @param  mixed  $job
+     * @return mixed
+     */
+    public function dispatchNow($job)
+    {
+        Qwatch::queued($job);
+
+        return app(Dispatcher::class)->dispatchNow($job);
+    }
+}


### PR DESCRIPTION
Implement #6 , #8 , #9

Deleted unused  file and line, also change associated line. (+2 squashed commits)
Squashed commits:
[4f65fc7] Use config queue of laravel instead of our Qwatcher cause Qwatcher doesn't have it own queue driver.
[ec46e23] Facade and update migration use for laravel 5.2

Use config queue of laravel instead of our Qwatcher cause Qwatcher doesn't have it own queue driver.

Deleted unused  file and line, also change associated line.